### PR TITLE
Add missing slash in file path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ module.exports = class Unlock {
                 prepend += '/';
             }
 
-            this.licenseWindow.loadFile(path.resolve(__dirname, prepend + 'license/license.html'), { query: { "data": JSON.stringify(this.config) } });
+            this.licenseWindow.loadFile(path.resolve(__dirname, prepend + '/license/license.html'), { query: { "data": JSON.stringify(this.config) } });
         } else {
             this.licenseWindow.loadFile(process.resourcesPath + '/license/license.html', { query: { "data": JSON.stringify(this.config) } });
         }

--- a/src/index.js
+++ b/src/index.js
@@ -142,14 +142,14 @@ module.exports = class Unlock {
             }
 
             if (path.resolve(__dirname).includes('node_modules') == false) {
-                prepend += 'node_modules/@anystack/electron-license';
+                prepend += 'node_modules/@anystack/electron-license/';
             }
 
             if (process.platform === 'darwin') {
                 prepend += '/';
             }
 
-            this.licenseWindow.loadFile(path.resolve(__dirname, prepend + '/license/license.html'), { query: { "data": JSON.stringify(this.config) } });
+            this.licenseWindow.loadFile(path.resolve(__dirname, prepend + 'license/license.html'), { query: { "data": JSON.stringify(this.config) } });
         } else {
             this.licenseWindow.loadFile(process.resourcesPath + '/license/license.html', { query: { "data": JSON.stringify(this.config) } });
         }


### PR DESCRIPTION
Hi,

I was not able to run the electron app in development mode, due to it not managing to find the file in the package:
![image](https://github.com/anystack-sh/electron-license/assets/81354124/dbcb992a-a809-43f5-b4f1-881e23c5ace3)

Looks like this is due to a slash missing from the file path.

Please let me know if I added the slash in the wrong spot:)